### PR TITLE
Fix pokedoll neither rotating nor mirroring

### DIFF
--- a/src/main/java/dev/mrshawn/pokeblocks/block/custom/PokedollBlock.java
+++ b/src/main/java/dev/mrshawn/pokeblocks/block/custom/PokedollBlock.java
@@ -8,7 +8,10 @@ import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.item.ItemStack;
 import net.minecraft.loot.context.LootContextParameterSet;
 import net.minecraft.state.StateManager;
+import net.minecraft.state.property.DirectionProperty;
 import net.minecraft.state.property.Properties;
+import net.minecraft.util.BlockMirror;
+import net.minecraft.util.BlockRotation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.shape.VoxelShape;
@@ -20,6 +23,8 @@ import java.util.List;
 import java.util.function.Supplier;
 
 public class PokedollBlock <T extends BlockEntity> extends BlockWithEntity {
+
+	public static final DirectionProperty FACING = HorizontalFacingBlock.FACING;
 
 	private Supplier<Class<T>> blockEntitySupplier;
 	private VoxelShape shape = Shapes.DOLL_SHAPE;
@@ -78,12 +83,22 @@ public class PokedollBlock <T extends BlockEntity> extends BlockWithEntity {
 	@Nullable
 	@Override
 	public BlockState getPlacementState(ItemPlacementContext ctx) {
-		return this.getDefaultState().with(Properties.HORIZONTAL_FACING, ctx.getHorizontalPlayerFacing().getOpposite());
+		return this.getDefaultState().with(FACING, ctx.getHorizontalPlayerFacing().getOpposite());
+	}
+
+	@Override
+	public BlockState rotate(BlockState state, BlockRotation rotation) {
+		return state.with(FACING, rotation.rotate(state.get(FACING)));
+	}
+
+	@Override
+	public BlockState mirror(BlockState state, BlockMirror mirror) {
+		return state.rotate(mirror.getRotation(state.get(FACING)));
 	}
 
 	@Override
 	protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
-		builder.add(Properties.HORIZONTAL_FACING);
+		builder.add(FACING);
 	}
 
 	@Override


### PR DESCRIPTION
Blocks with various state rotations need to implement rotate/mirror for use in structures.